### PR TITLE
pin slacker version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     long_description=read('README.rst'),
     install_requires=[
         'aiohttp>=1.3.0',
-        'slacker==0.9.42',
+        'slacker<=0.9.42',
     ],
     packages=['aioslacker'],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     long_description=read('README.rst'),
     install_requires=[
         'aiohttp>=1.3.0',
-        'slacker',
+        'slacker==0.9.42',
     ],
     packages=['aioslacker'],
     include_package_data=True,


### PR DESCRIPTION
Due to major changes with performing requests in `slacker` lib, https://github.com/os/slacker/commit/4405f6c7642ee340c898dc3475462ba04fda3d8f.
The quickest fix is to pin `slacker` version to the last session before the changes(0.9.42)